### PR TITLE
Add assignment grades CSV download command

### DIFF
--- a/cmd/gh-classroom/assignment-grades/assignment_grades.go
+++ b/cmd/gh-classroom/assignment-grades/assignment_grades.go
@@ -1,0 +1,75 @@
+package assignmentgrades
+
+import (
+	"encoding/csv"
+	"log"
+	"os"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/go-gh"
+	"github.com/github/gh-classroom/cmd/gh-classroom/shared"
+	"github.com/github/gh-classroom/pkg/classroom"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdAssignments(f *cmdutil.Factory) *cobra.Command {
+	var (
+		web          bool
+		assignmentID int
+		filename     string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "assignment-grades",
+		Example: `$ gh classroom assignment-grades -a 4876`,
+		Short:   "Download a CSV of grades for an assignment in a classroom",
+		Long:    "Download a CSV of grades for an assignment in a classroom",
+		Run: func(cmd *cobra.Command, args []string) {
+			client, err := gh.RESTClient(nil)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if assignmentID == 0 {
+				cr, err := shared.PromptForClassroom(client)
+				classroomID := cr.Id
+
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				assignment, err := shared.PromptForAssignment(client, classroomID)
+				if err != nil {
+					log.Fatal(err)
+				}
+				assignmentID = assignment.Id
+			}
+
+			response, err := classroom.GetAssignment(client, assignmentID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			grades := response.Grades
+			if len(grades) == 0 {
+				log.Fatal("No grades were returned for assignment")
+			}
+
+			f, err := os.Create(filename)
+			if err != nil {
+				log.Fatalln("failed to open file", err)
+			}
+			defer f.Close()
+
+			w := csv.NewWriter(f)
+			err = w.WriteAll(grades)
+			if err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+	cmd.Flags().BoolVar(&web, "web", false, "Open specified assignment in a web browser")
+	cmd.Flags().IntVarP(&assignmentID, "assignment-id", "a", 0, "Assignment ID (optional)")
+	cmd.Flags().StringVarP(&filename, "file-name", "f", "grades.csv", "File name (optional)")
+
+	return cmd
+}

--- a/cmd/gh-classroom/assignment-grades/assignment_grades_test.go
+++ b/cmd/gh-classroom/assignment-grades/assignment_grades_test.go
@@ -1,0 +1,117 @@
+package assignmentgrades
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestAssignmentGradesFatalOnInvalidAPIResponse(t *testing.T) {
+	// Run the crashing code when FLAG is set
+	if os.Getenv("FLAG") == "1" {
+		defer gock.Off()
+		t.Setenv("GITHUB_TOKEN", "999")
+
+		gock.New("https://api.github.com").
+			Get("/assignments/1").
+			Reply(200).
+			JSON(`{"id": 1,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+			}`)
+
+		actual := new(bytes.Buffer)
+
+		f := &cmdutil.Factory{}
+		command := NewCmdAssignments(f)
+		command.SetOut(actual)
+		command.SetErr(actual)
+		command.SetArgs([]string{
+			"-a1234",
+		})
+
+		command.Execute() //nolint:errcheck
+		return
+	}
+
+	// Runs the test above in a subprocess
+	cmd := exec.Command(os.Args[0], "-test.run=TestAssignmentGradesFatalOnInvalidAPIResponse")
+	cmd.Env = append(os.Environ(), "FLAG=1")
+	err := cmd.Run()
+
+	// Gets a fatal error
+	e, ok := err.(*exec.ExitError)
+	expectedErrorString := "exit status 1"
+	assert.Equal(t, true, ok)
+	assert.Equal(t, expectedErrorString, e.Error())
+}
+
+func TestGettingGrades(t *testing.T) {
+	t.Run("writes a csv when grades are returned from API", func(t *testing.T) {
+		defer gock.Off()
+		t.Setenv("GITHUB_TOKEN", "999")
+
+		// given an api response with grades returned
+		gock.New("https://api.github.com").
+			Get("/assignments/1").
+			Reply(200).
+			JSON(`{"id": 1,
+		"title": "Assignment 1",
+		"description": "This is the first assignment",
+		"due_date": "2018-01-01",
+		"classroom": {
+			"id": 1,
+			"name":      "Classroom Name"
+		},
+		"starter_code_repository": {
+			"id": 1,
+			"full_name": "org1/starter-code-repo"
+		},
+		"grades": [["student1", "0"], ["student2", "30"], ["student3", "100"]]
+		}`)
+
+		actual := new(bytes.Buffer)
+		outputFile := filepath.Join(t.TempDir(), "grades.csv")
+		f := &cmdutil.Factory{}
+		command := NewCmdAssignments(f)
+		command.SetOut(actual)
+		command.SetErr(actual)
+		command.SetArgs([]string{
+			"-a1234",
+			"-f" + outputFile,
+		})
+
+		// When the command is executed
+		err := command.Execute()
+
+		// There should:
+		// - be no error
+		// - be a CSV written to the file passed in
+		assert.NoError(t, err, "Should not error")
+
+		if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+			t.Errorf("Expected persisted file at %s, did not find it: %s", outputFile, err)
+		}
+		b, err := os.ReadFile(outputFile)
+		if err != nil {
+			fmt.Print(err)
+		}
+		assert.Equal(t, string(b), "student1,0\nstudent2,30\nstudent3,100\n")
+	})
+}

--- a/cmd/gh-classroom/root/root.go
+++ b/cmd/gh-classroom/root/root.go
@@ -6,6 +6,7 @@ import (
 
 	acceptedAssignments "github.com/github/gh-classroom/cmd/gh-classroom/accepted-assignments"
 	"github.com/github/gh-classroom/cmd/gh-classroom/assignment"
+	assignmentgrades "github.com/github/gh-classroom/cmd/gh-classroom/assignment-grades"
 	"github.com/github/gh-classroom/cmd/gh-classroom/assignments"
 	"github.com/github/gh-classroom/cmd/gh-classroom/clone"
 	"github.com/github/gh-classroom/cmd/gh-classroom/list"
@@ -24,6 +25,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(assignment.NewCmdAssignment(f))
 	cmd.AddCommand(acceptedAssignments.NewCmdAcceptedAssignments(f))
 	cmd.AddCommand(clone.NewCmdClone(f))
+	cmd.AddCommand(assignmentgrades.NewCmdAssignments(f))
 
 	return cmd
 }

--- a/pkg/classroom/classroom.go
+++ b/pkg/classroom/classroom.go
@@ -31,6 +31,7 @@ type Assignment struct {
 	Deadline                    string           `json:"deadline"`
 	Classroom                   Classroom        `json:"classroom"`
 	StarterCodeRepository       GithubRepository `json:"starter_code_repository"`
+	Grades                      [][]string       `json:"grades"` // TODO: return this from the GitHub API
 }
 
 type Classroom struct {


### PR DESCRIPTION
Fixes https://github.com/github/gh-classroom/issues/5

Instead of creating a new API endpoint for grades, I think it makes sense to return grades as part of the assignment response. This will allow us to piggy back on existing CLI tooling. 

Pre-requisites:
- [ ] Return grades in assignment API call request