### PR TITLE
Implementation for issue #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 *.swp
 
 vendor/
+
+# Windows
+gh-classroom.exe

--- a/cmd/gh-classroom/accepted-assignments/accepted_assignments.go
+++ b/cmd/gh-classroom/accepted-assignments/accepted_assignments.go
@@ -63,7 +63,7 @@ func NewCmdAcceptedAssignments(f *cmdutil.Factory) *cobra.Command {
 				return
 			}
 
-			acceptedAssignments, err := classroom.ListAcceptedAssignments(client, assignmentId, page, perPage)
+			acceptedAssignments, err := shared.ListAcceptedAssignments(client, assignmentId, page, perPage)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/gh-classroom/clone/student-repos/student-repos.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos.go
@@ -102,7 +102,7 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVarP(&assignmentId, "assignment-id", "a", 0, "ID of the assignment")
 	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Directory to clone into")
 	cmd.Flags().IntVar(&page, "page", 1, "Page number")
-	cmd.Flags().IntVar(&perPage, "per-page", 30, "Number of accepted assignments per page")
+	cmd.Flags().IntVar(&perPage, "per-page", 15, "Number of accepted assignments per page")
 	cmd.Flags().BoolVar(&getAll, "all", true, "Clone All assignments by default")
 
 	return cmd

--- a/cmd/gh-classroom/clone/student-repos/student-repos.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos.go
@@ -20,6 +20,7 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 	var directory string
 	var page int
 	var perPage int
+	var getAll bool
 
 	cmd := &cobra.Command{
 		Use:   "student-repos",
@@ -51,8 +52,12 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 					log.Fatal(err)
 				}
 			}
-
-			acceptedAssignmentList, err := classroom.ListAcceptedAssignments(client, assignmentId, page, perPage)
+			var acceptedAssignmentList classroom.AcceptedAssignmentList
+			if getAll {
+				acceptedAssignmentList, err = classroom.ListAllAcceptedAssignments(client, assignmentId, perPage)
+			} else {
+				acceptedAssignmentList, err = classroom.ListAcceptedAssignments(client, assignmentId, page, perPage)
+			}
 
 			if err != nil {
 				log.Fatal(err)
@@ -98,6 +103,7 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Directory to clone into")
 	cmd.Flags().IntVar(&page, "page", 1, "Page number")
 	cmd.Flags().IntVar(&perPage, "per-page", 30, "Number of accepted assignments per page")
+	cmd.Flags().BoolVar(&getAll, "all", true, "Clone All assignments by default")
 
 	return cmd
 }

--- a/cmd/gh-classroom/clone/student-repos/student-repos.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos.go
@@ -54,9 +54,9 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 			}
 			var acceptedAssignmentList classroom.AcceptedAssignmentList
 			if getAll {
-				acceptedAssignmentList, err = classroom.ListAllAcceptedAssignments(client, assignmentId, perPage)
+				acceptedAssignmentList, err = shared.ListAllAcceptedAssignments(client, assignmentId, perPage)
 			} else {
-				acceptedAssignmentList, err = classroom.ListAcceptedAssignments(client, assignmentId, page, perPage)
+				acceptedAssignmentList, err = shared.ListAcceptedAssignments(client, assignmentId, page, perPage)
 			}
 
 			if err != nil {

--- a/cmd/gh-classroom/shared/shared.go
+++ b/cmd/gh-classroom/shared/shared.go
@@ -94,3 +94,45 @@ func PromptForAssignment(client api.RESTClient, classroomId int) (assignment cla
 
 	return optionMap[answer.Assignment], nil
 }
+
+func ListAcceptedAssignments(client api.RESTClient, assignmentID int, page int, perPage int) (classroom.AcceptedAssignmentList, error) {
+	response, err := classroom.GetAssignmentList(client, assignmentID, page, perPage)
+	if err != nil {
+		return classroom.AcceptedAssignmentList{}, err
+	}
+
+	if len(response) == 0 {
+		return classroom.AcceptedAssignmentList{}, nil
+	}
+	acceptedAssignmentList := classroom.NewAcceptedAssignmentList(response)
+
+	return acceptedAssignmentList, nil
+}
+
+func ListAllAcceptedAssignments(client api.RESTClient, assignmentID int, perPage int) (classroom.AcceptedAssignmentList, error) {
+	var page = 1
+	response, err := classroom.GetAssignmentList(client, assignmentID, page, perPage)
+	if err != nil {
+		return classroom.AcceptedAssignmentList{}, err
+	}
+
+	if len(response) == 0 {
+		return classroom.AcceptedAssignmentList{}, nil
+	}
+
+	//keep calling getAssignmentList until we get them all
+	var nextList []classroom.AcceptedAssignment
+	for hasNext := true; hasNext; {
+		page += 1
+		nextList, err = classroom.GetAssignmentList(client, assignmentID, page, perPage)
+		if err != nil {
+			return classroom.AcceptedAssignmentList{}, err
+		}
+		hasNext = len(nextList) > 0
+		response = append(response, nextList...)
+	}
+
+	acceptedAssignmentList := classroom.NewAcceptedAssignmentList(response)
+
+	return acceptedAssignmentList, nil
+}

--- a/cmd/gh-classroom/shared/shared_test.go
+++ b/cmd/gh-classroom/shared/shared_test.go
@@ -1,0 +1,181 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/cli/go-gh"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestListAcceptedAssignments(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "999")
+	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[{"id": 1,
+		"assignment": {
+			"id": 1,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+		},
+		"students": [{
+			"id": 1,
+			"login": "student1"
+		}],
+		"repository": {
+			"id": 1,
+			"full_name": "org1/student1-repo"
+		}
+	}]`)
+
+	gock.New("https://api.github.com").
+		Path("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[{"id": 2,
+		"assignment": {
+			"id": 2,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+		},
+		"students": [{
+			"id": 2,
+			"login": "student2"
+		}],
+		"repository": {
+			"id": 2,
+			"full_name": "org1/student2-repo"
+		}
+	}]`)
+
+	client, err := gh.RESTClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Ask for page 1 and 1 per page
+	actual, err := ListAcceptedAssignments(client, 1, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, actual.Count)
+	assert.Equal(t, 1, actual.AcceptedAssignments[0].Id)
+	assert.Equal(t, "org1/student1-repo", actual.AcceptedAssignments[0].Repository.FullName)
+	assert.Equal(t, "student1", actual.AcceptedAssignments[0].Students[0].Login)
+
+	//Ask for page 2 and 1 per page
+	actual, err = ListAcceptedAssignments(client, 1, 2, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, actual.Count)
+	assert.Equal(t, 2, actual.AcceptedAssignments[0].Id)
+	assert.Equal(t, "org1/student2-repo", actual.AcceptedAssignments[0].Repository.FullName)
+	assert.Equal(t, "student2", actual.AcceptedAssignments[0].Students[0].Login)
+
+}
+
+func TestListAllAcceptedAssignments(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "999")
+	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[{"id": 1,
+		"assignment": {
+			"id": 1,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+		},
+		"students": [{
+			"id": 1,
+			"login": "student1"
+		}],
+		"repository": {
+			"id": 1,
+			"full_name": "org1/student1-repo"
+		}
+	}]`)
+
+	gock.New("https://api.github.com").
+		Path("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[{"id": 2,
+		"assignment": {
+			"id": 2,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+		},
+		"students": [{
+			"id": 2,
+			"login": "student2"
+		}],
+		"repository": {
+			"id": 2,
+			"full_name": "org1/student2-repo"
+		}
+	}]`)
+
+	gock.New("https://api.github.com").
+		Get("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[]`)
+
+	client, err := gh.RESTClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := ListAllAcceptedAssignments(client, 1, 1)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, actual.Count)
+	assert.Equal(t, 1, actual.AcceptedAssignments[0].Id)
+	assert.Equal(t, "org1/student1-repo", actual.AcceptedAssignments[0].Repository.FullName)
+	assert.Equal(t, "student1", actual.AcceptedAssignments[0].Students[0].Login)
+	assert.Equal(t, 2, actual.AcceptedAssignments[1].Id)
+	assert.Equal(t, "org1/student2-repo", actual.AcceptedAssignments[1].Repository.FullName)
+	assert.Equal(t, "student2", actual.AcceptedAssignments[1].Students[0].Login)
+}

--- a/pkg/classroom/http.go
+++ b/pkg/classroom/http.go
@@ -33,52 +33,14 @@ func ListClassrooms(client api.RESTClient, page int, perPage int) ([]Classroom, 
 	return response, nil
 }
 
-func getAssignmentList(client api.RESTClient, assignmentID int, page int, perPage int) ([]AcceptedAssignment, error) {
+func GetAssignmentList(client api.RESTClient, assignmentID int, page int, perPage int) ([]AcceptedAssignment, error) {
 	var response []AcceptedAssignment
+
 	err := client.Get(fmt.Sprintf("assignments/%v/accepted_assignments?page=%v&per_page=%v", assignmentID, page, perPage), &response)
-	return response, err
-}
-
-func ListAcceptedAssignments(client api.RESTClient, assignmentID int, page int, perPage int) (AcceptedAssignmentList, error) {
-	response, err := getAssignmentList(client, assignmentID, page, perPage)
 	if err != nil {
-		return AcceptedAssignmentList{}, err
+		return nil, err
 	}
-
-	if len(response) == 0 {
-		return AcceptedAssignmentList{}, nil
-	}
-	acceptedAssignmentList := NewAcceptedAssignmentList(response)
-
-	return acceptedAssignmentList, nil
-}
-
-func ListAllAcceptedAssignments(client api.RESTClient, assignmentID int, perPage int) (AcceptedAssignmentList, error) {
-	var page = 1
-	response, err := getAssignmentList(client, assignmentID, page, perPage)
-	if err != nil {
-		return AcceptedAssignmentList{}, err
-	}
-
-	if len(response) == 0 {
-		return AcceptedAssignmentList{}, nil
-	}
-
-	//keep calling getAssignmentList until we get them all
-	var nextList []AcceptedAssignment
-	for hasNext := true; hasNext; {
-		page += 1
-		nextList, err = getAssignmentList(client, assignmentID, page, perPage)
-		if err != nil {
-			return AcceptedAssignmentList{}, err
-		}
-		hasNext = len(nextList) > 0
-		response = append(response, nextList...)
-	}
-
-	acceptedAssignmentList := NewAcceptedAssignmentList(response)
-
-	return acceptedAssignmentList, nil
+	return response, nil
 }
 
 func GetAssignment(client api.RESTClient, assignmentID int) (Assignment, error) {

--- a/pkg/classroom/http.go
+++ b/pkg/classroom/http.go
@@ -64,7 +64,7 @@ func ListAllAcceptedAssignments(client api.RESTClient, assignmentID int, perPage
 		return AcceptedAssignmentList{}, nil
 	}
 
-	//keep calling ListAcceptedAssignments until we get them all
+	//keep calling getAssignmentList until we get them all
 	var nextList []AcceptedAssignment
 	for hasNext := true; hasNext; {
 		page += 1
@@ -74,10 +74,6 @@ func ListAllAcceptedAssignments(client api.RESTClient, assignmentID int, perPage
 		}
 		hasNext = len(nextList) > 0
 		response = append(response, nextList...)
-	}
-
-	if len(response) == 0 {
-		return AcceptedAssignmentList{}, nil
 	}
 
 	acceptedAssignmentList := NewAcceptedAssignmentList(response)

--- a/pkg/classroom/http_test.go
+++ b/pkg/classroom/http_test.go
@@ -99,21 +99,144 @@ func TestListAcceptedAssignments(t *testing.T) {
 		}
 	}]`)
 
+	gock.New("https://api.github.com").
+		Path("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[{"id": 2,
+		"assignment": {
+			"id": 2,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+		},
+		"students": [{
+			"id": 2,
+			"login": "student2"
+		}],
+		"repository": {
+			"id": 2,
+			"full_name": "org1/student2-repo"
+		}
+	}]`)
+
 	client, err := gh.RESTClient(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := ListAcceptedAssignments(client, 1, 1, 30)
+	//Ask for page 1 and 1 per page
+	actual, err := ListAcceptedAssignments(client, 1, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, actual.Count)
+	assert.Equal(t, 1, actual.AcceptedAssignments[0].Id)
+	assert.Equal(t, "org1/student1-repo", actual.AcceptedAssignments[0].Repository.FullName)
+	assert.Equal(t, "student1", actual.AcceptedAssignments[0].Students[0].Login)
+
+	//Ask for page 2 and 1 per page
+	actual, err = ListAcceptedAssignments(client, 1, 2, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, actual.Count)
+	assert.Equal(t, 2, actual.AcceptedAssignments[0].Id)
+	assert.Equal(t, "org1/student2-repo", actual.AcceptedAssignments[0].Repository.FullName)
+	assert.Equal(t, "student2", actual.AcceptedAssignments[0].Students[0].Login)
+
+}
+
+func TestListAllAcceptedAssignments(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "999")
+	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[{"id": 1,
+		"assignment": {
+			"id": 1,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+		},
+		"students": [{
+			"id": 1,
+			"login": "student1"
+		}],
+		"repository": {
+			"id": 1,
+			"full_name": "org1/student1-repo"
+		}
+	}]`)
+
+	gock.New("https://api.github.com").
+		Path("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[{"id": 2,
+		"assignment": {
+			"id": 2,
+			"title": "Assignment 1",
+			"description": "This is the first assignment",
+			"due_date": "2018-01-01",
+			"classroom": {
+				"id": 1,
+				"name":      "Classroom Name"
+			},
+			"starter_code_repository": {
+				"id": 1,
+				"full_name": "org1/starter-code-repo"
+			}
+		},
+		"students": [{
+			"id": 2,
+			"login": "student2"
+		}],
+		"repository": {
+			"id": 2,
+			"full_name": "org1/student2-repo"
+		}
+	}]`)
+
+	gock.New("https://api.github.com").
+		Get("/assignments/1/accepted_assignments").
+		Reply(200).
+		JSON(`[]`)
+
+	client, err := gh.RESTClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := ListAllAcceptedAssignments(client, 1, 1)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 1, actual.Count)
+	assert.Equal(t, 2, actual.Count)
 	assert.Equal(t, 1, actual.AcceptedAssignments[0].Id)
 	assert.Equal(t, "org1/student1-repo", actual.AcceptedAssignments[0].Repository.FullName)
 	assert.Equal(t, "student1", actual.AcceptedAssignments[0].Students[0].Login)
+	assert.Equal(t, 2, actual.AcceptedAssignments[1].Id)
+	assert.Equal(t, "org1/student2-repo", actual.AcceptedAssignments[1].Repository.FullName)
+	assert.Equal(t, "student2", actual.AcceptedAssignments[1].Students[0].Login)
 }
 
 func TestGetAssignment(t *testing.T) {

--- a/pkg/classroom/http_test.go
+++ b/pkg/classroom/http_test.go
@@ -67,7 +67,7 @@ func TestListClassrooms(t *testing.T) {
 	assert.Equal(t, "Classroom Name", actual[0].Name)
 }
 
-func TestListAcceptedAssignments(t *testing.T) {
+func TestGetAssignmentList(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "999")
 	defer gock.Off()
 
@@ -97,14 +97,10 @@ func TestListAcceptedAssignments(t *testing.T) {
 			"id": 1,
 			"full_name": "org1/student1-repo"
 		}
-	}]`)
-
-	gock.New("https://api.github.com").
-		Path("/assignments/1/accepted_assignments").
-		Reply(200).
-		JSON(`[{"id": 2,
+	},
+	{"id": 2,
 		"assignment": {
-			"id": 2,
+			"id": 1,
 			"title": "Assignment 1",
 			"description": "This is the first assignment",
 			"due_date": "2018-01-01",
@@ -132,111 +128,22 @@ func TestListAcceptedAssignments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//Ask for page 1 and 1 per page
-	actual, err := ListAcceptedAssignments(client, 1, 1, 1)
+	//Ask for page 1 and 15 per page
+	actual, err := GetAssignmentList(client, 1, 1, 15)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 1, actual.Count)
-	assert.Equal(t, 1, actual.AcceptedAssignments[0].Id)
-	assert.Equal(t, "org1/student1-repo", actual.AcceptedAssignments[0].Repository.FullName)
-	assert.Equal(t, "student1", actual.AcceptedAssignments[0].Students[0].Login)
+	assert.Equal(t, 2, len(actual))
+	//check 1st entry
+	assert.Equal(t, 1, actual[0].Id)
+	assert.Equal(t, "org1/student1-repo", actual[0].Repository.FullName)
+	assert.Equal(t, "student1", actual[0].Students[0].Login)
 
-	//Ask for page 2 and 1 per page
-	actual, err = ListAcceptedAssignments(client, 1, 2, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, 1, actual.Count)
-	assert.Equal(t, 2, actual.AcceptedAssignments[0].Id)
-	assert.Equal(t, "org1/student2-repo", actual.AcceptedAssignments[0].Repository.FullName)
-	assert.Equal(t, "student2", actual.AcceptedAssignments[0].Students[0].Login)
+	//check 2nd entry
+	assert.Equal(t, 2, actual[1].Id)
+	assert.Equal(t, "org1/student2-repo", actual[1].Repository.FullName)
+	assert.Equal(t, "student2", actual[1].Students[0].Login)
 
-}
-
-func TestListAllAcceptedAssignments(t *testing.T) {
-	t.Setenv("GITHUB_TOKEN", "999")
-	defer gock.Off()
-
-	gock.New("https://api.github.com").
-		Get("/assignments/1/accepted_assignments").
-		Reply(200).
-		JSON(`[{"id": 1,
-		"assignment": {
-			"id": 1,
-			"title": "Assignment 1",
-			"description": "This is the first assignment",
-			"due_date": "2018-01-01",
-			"classroom": {
-				"id": 1,
-				"name":      "Classroom Name"
-			},
-			"starter_code_repository": {
-				"id": 1,
-				"full_name": "org1/starter-code-repo"
-			}
-		},
-		"students": [{
-			"id": 1,
-			"login": "student1"
-		}],
-		"repository": {
-			"id": 1,
-			"full_name": "org1/student1-repo"
-		}
-	}]`)
-
-	gock.New("https://api.github.com").
-		Path("/assignments/1/accepted_assignments").
-		Reply(200).
-		JSON(`[{"id": 2,
-		"assignment": {
-			"id": 2,
-			"title": "Assignment 1",
-			"description": "This is the first assignment",
-			"due_date": "2018-01-01",
-			"classroom": {
-				"id": 1,
-				"name":      "Classroom Name"
-			},
-			"starter_code_repository": {
-				"id": 1,
-				"full_name": "org1/starter-code-repo"
-			}
-		},
-		"students": [{
-			"id": 2,
-			"login": "student2"
-		}],
-		"repository": {
-			"id": 2,
-			"full_name": "org1/student2-repo"
-		}
-	}]`)
-
-	gock.New("https://api.github.com").
-		Get("/assignments/1/accepted_assignments").
-		Reply(200).
-		JSON(`[]`)
-
-	client, err := gh.RESTClient(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	actual, err := ListAllAcceptedAssignments(client, 1, 1)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, 2, actual.Count)
-	assert.Equal(t, 1, actual.AcceptedAssignments[0].Id)
-	assert.Equal(t, "org1/student1-repo", actual.AcceptedAssignments[0].Repository.FullName)
-	assert.Equal(t, "student1", actual.AcceptedAssignments[0].Students[0].Login)
-	assert.Equal(t, 2, actual.AcceptedAssignments[1].Id)
-	assert.Equal(t, "org1/student2-repo", actual.AcceptedAssignments[1].Repository.FullName)
-	assert.Equal(t, "student2", actual.AcceptedAssignments[1].Students[0].Login)
 }
 
 func TestGetAssignment(t *testing.T) {


### PR DESCRIPTION
### What are you trying to accomplish?

Implementation for issue #4 

Downloading all the student repo is now the default behavior. All the original functionality such as downloading per page still exists. In almost all cases that I can think of an instructor or TA/LA wants all the assignments for a class so by default this feature is enabled and must be explicitly turned off to got back to the original. 

### What approach did you choose and why?

I added a new function and associated tests to get all the assignments. The new function simply calls the rest API in a loop until it receives no more input. 

### What should reviewers focus on?

I haven't written much go code so any feedback is appreciated :) 
