### PR TITLE
Add ability to pull student repos issue #8

### DIFF
--- a/cmd/gh-classroom/clone/student-repos/student-repos.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos.go
@@ -20,7 +20,6 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 	var directory string
 	var page int
 	var perPage int
-	var sync bool
 	var getAll bool
 
 	cmd := &cobra.Command{
@@ -28,7 +27,8 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 		Short: "Clone student repos for an assignment",
 		Long: heredoc.Doc(`Clone student repos for an assignment into a directory.
 
-		By default, the student repos are cloned into the current directory a directory named after the assignment slug. To clone into a different directory, use the --directory flag.
+		By default, the student repos are cloned into the current directory in a directory named after the assignment slug.
+		To clone into a different directory, use the --directory flag.
 
 		If the directory does not exists, it will be created.
 		`),
@@ -88,12 +88,6 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			//Save off the cwd so we can restore it if we do a sync
-			baseDir, err := os.Getwd()
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
 			for _, acceptAssignment := range acceptedAssignmentList.AcceptedAssignments {
 				clonePath := filepath.Join(fullPath, acceptAssignment.Repository.Name())
 				if _, err := os.Stat(clonePath); os.IsNotExist(err) {
@@ -103,28 +97,9 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 						log.Fatal(err)
 						return
 					}
-				} else if sync {
-					err = os.Chdir(clonePath)
-					if err != nil {
-						log.Fatal(err)
-						return
-					}
-					fmt.Printf("Syncing repo: %v\n", clonePath)
-					_, _, err := gh.Exec("repo", "sync")
-					if err != nil {
-						log.Fatal(err)
-						return
-					}
-					err = os.Chdir(baseDir)
-					if err != nil {
-						log.Fatal(err)
-						return
-					}
-
 				} else {
-					fmt.Printf("Skip existing repo: %v use --sync to pull down commits\n", clonePath)
+					fmt.Printf("Skip existing repo: %v use gh classroom pull to get new commits\n", clonePath)
 				}
-
 			}
 		},
 	}
@@ -133,7 +108,6 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Directory to clone into")
 	cmd.Flags().IntVar(&page, "page", 1, "Page number")
 	cmd.Flags().IntVar(&perPage, "per-page", 15, "Number of accepted assignments per page")
-	cmd.Flags().BoolVar(&sync, "sync", false, "If the repository has already been cloned run gh repo sync instead")
 	cmd.Flags().BoolVar(&getAll, "all", true, "Clone All assignments by default")
 
 	return cmd

--- a/cmd/gh-classroom/pull/pull.go
+++ b/cmd/gh-classroom/pull/pull.go
@@ -1,0 +1,109 @@
+package pull
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/go-gh"
+	"github.com/github/gh-classroom/cmd/gh-classroom/shared"
+	"github.com/github/gh-classroom/pkg/classroom"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdPull(f *cmdutil.Factory) *cobra.Command {
+	var assignmentId int
+	var directory string
+
+	cmd := &cobra.Command{
+		Use:   "pull",
+		Short: "Run pull on an existing set of repositories",
+		Long: heredoc.Doc(`Iterate through an existing set of directories that
+		were previously cloned and run pull to get any new commits.
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			client, err := gh.RESTClient(nil)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if assignmentId == 0 {
+				classroom, err := shared.PromptForClassroom(client)
+
+				if err != nil {
+					log.Fatal(err)
+				}
+				classroomId := classroom.Id
+
+				assignment, err := shared.PromptForAssignment(client, classroomId)
+				if err != nil {
+					log.Fatal(err)
+				}
+				assignmentId = assignment.Id
+			}
+
+			assignment, err := classroom.GetAssignment(client, assignmentId)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if strings.HasPrefix(directory, "~") {
+				dirname, _ := os.UserHomeDir()
+				directory = filepath.Join(dirname, directory[1:])
+			}
+
+			fullPath, err := filepath.Abs(filepath.Join(directory, assignment.Slug+"-submissions"))
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+				fmt.Println("Directories don't exist run gh classroom clone first")
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+
+			//Save off the cwd so we can restore when we run gh sync
+			baseDir, err := os.Getwd()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			entries, err := os.ReadDir(fullPath)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			for _, r := range entries {
+				clonePath := filepath.Join(fullPath, r.Name())
+				fmt.Printf("Pulling repo: %v\n", clonePath)
+				err = os.Chdir(clonePath)
+				if err != nil {
+					log.Fatal(err)
+				}
+				_, _, err := gh.Exec("repo", "sync")
+				if err != nil {
+					//Don't bail on an error the repo could have changes preventing
+					//a pull, continue with rest of repos
+					fmt.Println(err)
+				}
+				err = os.Chdir(baseDir)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+		},
+	}
+
+	cmd.Flags().IntVarP(&assignmentId, "assignment-id", "a", 0, "ID of the assignment")
+	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Directory to that the repos live in")
+
+	return cmd
+}

--- a/cmd/gh-classroom/pull/starter-repo/starter-repo.go
+++ b/cmd/gh-classroom/pull/starter-repo/starter-repo.go
@@ -62,7 +62,6 @@ func NewCmdStarterRepoPull(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			fullPath, err := filepath.Abs(filepath.Join(directory, assignment.Slug))
-
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/gh-classroom/pull/starter-repo/starter-repo.go
+++ b/cmd/gh-classroom/pull/starter-repo/starter-repo.go
@@ -1,0 +1,92 @@
+package starter_repo
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/go-gh"
+	"github.com/github/gh-classroom/cmd/gh-classroom/shared"
+	"github.com/github/gh-classroom/pkg/classroom"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdStarterRepoPull(f *cmdutil.Factory) *cobra.Command {
+	var assignmentId int
+	var directory string
+
+	cmd := &cobra.Command{
+		Use:   "starter-repo",
+		Short: "Run pull on an existing starter repository",
+		Long: heredoc.Doc(`Given a starter repository that was previously cloned run a pull to get any new commits.
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			client, err := gh.RESTClient(nil)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if assignmentId == 0 {
+				classroom, err := shared.PromptForClassroom(client)
+
+				if err != nil {
+					log.Fatal(err)
+				}
+				classroomId := classroom.Id
+
+				assignment, err := shared.PromptForAssignment(client, classroomId)
+				if err != nil {
+					log.Fatal(err)
+				}
+				assignmentId = assignment.Id
+			}
+
+			assignment, err := classroom.GetAssignment(client, assignmentId)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if assignment.StarterCodeRepository.FullName == "" {
+				fmt.Println("No starter code repository found for this assignment.")
+				return
+			}
+
+			if strings.HasPrefix(directory, "~") {
+				dirname, _ := os.UserHomeDir()
+				directory = filepath.Join(dirname, directory[1:])
+			}
+
+			fullPath, err := filepath.Abs(filepath.Join(directory, assignment.Slug))
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+				fmt.Println("Starter code don't exist run gh classroom clone starter-code first")
+				return
+			}
+			fmt.Println("Pulling: ", fullPath)
+			err = os.Chdir(fullPath)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			_, se, err := gh.Exec("repo", "sync")
+			if err != nil {
+				fmt.Println(se.String())
+				return
+			}
+		},
+	}
+
+	cmd.Flags().IntVarP(&assignmentId, "assignment-id", "a", 0, "ID of the assignment")
+	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Directory to that the repos live in")
+
+	return cmd
+}

--- a/cmd/gh-classroom/pull/student-repos/student-repos.go
+++ b/cmd/gh-classroom/pull/student-repos/student-repos.go
@@ -57,7 +57,6 @@ func NewCmdStudentReposPull(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			fullPath, err := filepath.Abs(filepath.Join(directory, assignment.Slug+"-submissions"))
-
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/gh-classroom/pull/student-repos/student-repos.go
+++ b/cmd/gh-classroom/pull/student-repos/student-repos.go
@@ -1,0 +1,106 @@
+package student_repos
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/go-gh"
+	"github.com/github/gh-classroom/cmd/gh-classroom/shared"
+	"github.com/github/gh-classroom/pkg/classroom"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdStudentReposPull(f *cmdutil.Factory) *cobra.Command {
+	var assignmentId int
+	var directory string
+
+	cmd := &cobra.Command{
+		Use:   "student-repos",
+		Short: "Run pull on an existing set of student repositories",
+		Long: heredoc.Doc(`Given a previously cloned set of student repositories run a pull on each one to get any new commits.
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			client, err := gh.RESTClient(nil)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if assignmentId == 0 {
+				classroom, err := shared.PromptForClassroom(client)
+
+				if err != nil {
+					log.Fatal(err)
+				}
+				classroomId := classroom.Id
+
+				assignment, err := shared.PromptForAssignment(client, classroomId)
+				if err != nil {
+					log.Fatal(err)
+				}
+				assignmentId = assignment.Id
+			}
+
+			assignment, err := classroom.GetAssignment(client, assignmentId)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if strings.HasPrefix(directory, "~") {
+				dirname, _ := os.UserHomeDir()
+				directory = filepath.Join(dirname, directory[1:])
+			}
+
+			fullPath, err := filepath.Abs(filepath.Join(directory, assignment.Slug+"-submissions"))
+
+			if err != nil {
+				log.Fatal(err)
+			}
+			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+				fmt.Println("Directories don't exist run gh classroom clone student-repos first")
+				return
+			}
+
+			//Save off the cwd so we can restore when we run gh sync
+			baseDir, err := os.Getwd()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			entries, err := os.ReadDir(fullPath)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			for _, r := range entries {
+				clonePath := filepath.Join(fullPath, r.Name())
+				fmt.Printf("Pulling repo: %v\n", clonePath)
+				err = os.Chdir(clonePath)
+				if err != nil {
+					log.Fatal(err)
+				}
+				_, _, err := gh.Exec("repo", "sync")
+				if err != nil {
+					//Don't bail on an error the repo could have changes preventing
+					//a pull, continue with rest of repos
+					fmt.Println(err)
+				}
+				err = os.Chdir(baseDir)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+
+		},
+	}
+
+	cmd.Flags().IntVarP(&assignmentId, "assignment-id", "a", 0, "ID of the assignment")
+	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Directory to that the repos live in")
+
+	return cmd
+}

--- a/cmd/gh-classroom/root/root.go
+++ b/cmd/gh-classroom/root/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/github/gh-classroom/cmd/gh-classroom/assignments"
 	"github.com/github/gh-classroom/cmd/gh-classroom/clone"
 	"github.com/github/gh-classroom/cmd/gh-classroom/list"
+	"github.com/github/gh-classroom/cmd/gh-classroom/pull"
 	"github.com/github/gh-classroom/cmd/gh-classroom/view"
 )
 
@@ -26,6 +27,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(acceptedAssignments.NewCmdAcceptedAssignments(f))
 	cmd.AddCommand(clone.NewCmdClone(f))
 	cmd.AddCommand(assignmentgrades.NewCmdAssignmentGrades(f))
+	cmd.AddCommand(pull.NewCmdPull(f))
 
 	return cmd
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Change the default behavior when cloning student repos to skip any repos that have already been cloned. Add in a command line flag to allow existing repos to be sync'd instead of a full clone.

Fix issue #14
Implements Feature #8

### What approach did you choose and why?

Instead of doing a fresh clone every single time, skip any repos that have already been cloned and give the user a new command line flag to sync. If the user wants a fresh clone then they can already use the --directory flag to do so.

UPDATE: This change should take some pressure off your endpoint :)

### What should reviewers focus on?

I couldn't see anywhere in the documentation where the **gh** cli allows you to pass a path when performing a **sync** so I had to change the working directory. If there is a better way to do a sync with the gh client please let me know :) 

