### PR TITLE
Simple retry loop for issue #38

### DIFF
--- a/pkg/classroom/http.go
+++ b/pkg/classroom/http.go
@@ -6,9 +6,20 @@ import (
 	"github.com/cli/go-gh/pkg/api"
 )
 
+const MaxRetry = 5
+
+func getRetry(client api.RESTClient, path string, response interface{}) (numRetry int, err error) {
+	err = client.Get(path, &response)
+	for ; err != nil && numRetry < MaxRetry; numRetry++ {
+		err = client.Get(path, &response)
+		fmt.Printf("%s retry %d of %d\n", err.Error(), numRetry+1, MaxRetry)
+	}
+	return
+}
+
 func ListAssignments(client api.RESTClient, classroomID int, page int, perPage int) (AssignmentList, error) {
 	var response []Assignment
-	err := client.Get(fmt.Sprintf("classrooms/%v/assignments?page=%v&per_page=%v", classroomID, page, perPage), &response)
+	_, err := getRetry(client, fmt.Sprintf("classrooms/%v/assignments?page=%v&per_page=%v", classroomID, page, perPage), &response)
 	if err != nil {
 		return AssignmentList{}, err
 	}
@@ -25,7 +36,7 @@ func ListAssignments(client api.RESTClient, classroomID int, page int, perPage i
 func ListClassrooms(client api.RESTClient, page int, perPage int) ([]Classroom, error) {
 	var response []Classroom
 
-	err := client.Get(fmt.Sprintf("classrooms?page=%v&per_page=%v", page, perPage), &response)
+	_, err := getRetry(client, fmt.Sprintf("classrooms?page=%v&per_page=%v", page, perPage), &response)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +47,7 @@ func ListClassrooms(client api.RESTClient, page int, perPage int) ([]Classroom, 
 func GetAssignmentList(client api.RESTClient, assignmentID int, page int, perPage int) ([]AcceptedAssignment, error) {
 	var response []AcceptedAssignment
 
-	err := client.Get(fmt.Sprintf("assignments/%v/accepted_assignments?page=%v&per_page=%v", assignmentID, page, perPage), &response)
+	_, err := getRetry(client, fmt.Sprintf("assignments/%v/accepted_assignments?page=%v&per_page=%v", assignmentID, page, perPage), &response)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +56,7 @@ func GetAssignmentList(client api.RESTClient, assignmentID int, page int, perPag
 
 func GetAssignment(client api.RESTClient, assignmentID int) (Assignment, error) {
 	var response Assignment
-	err := client.Get(fmt.Sprintf("assignments/%v", assignmentID), &response)
+	_, err := getRetry(client, fmt.Sprintf("assignments/%v", assignmentID), &response)
 	if err != nil {
 		return Assignment{}, err
 	}
@@ -54,7 +65,7 @@ func GetAssignment(client api.RESTClient, assignmentID int) (Assignment, error) 
 
 func GetAssignmentGrades(client api.RESTClient, assignmentID int) ([]AssignmentGrade, error) {
 	var response []AssignmentGrade
-	err := client.Get(fmt.Sprintf("assignments/%v/grades", assignmentID), &response)
+	_, err := getRetry(client, fmt.Sprintf("assignments/%v/grades", assignmentID), &response)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +75,7 @@ func GetAssignmentGrades(client api.RESTClient, assignmentID int) ([]AssignmentG
 func GetClassroom(client api.RESTClient, classroomID int) (Classroom, error) {
 	var response Classroom
 
-	err := client.Get(fmt.Sprintf("classrooms/%v", classroomID), &response)
+	_, err := getRetry(client, fmt.Sprintf("classrooms/%v", classroomID), &response)
 	if err != nil {
 		return Classroom{}, err
 	}

--- a/pkg/classroom/http_test.go
+++ b/pkg/classroom/http_test.go
@@ -8,6 +8,24 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
+func TestGetRetry(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "999")
+	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/").
+		Reply(500)
+
+	client, err := gh.RESTClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var foo interface{}
+	numRetry, err := getRetry(client, "https://api.github.com", foo)
+	assert.NotNil(t, err)
+	assert.Equal(t, numRetry, MaxRetry)
+}
+
 func TestListAssignments(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "999")
 	defer gock.Off()


### PR DESCRIPTION
### What are you trying to accomplish?

Issue #38 still seems to be popping up quite a bit. In addition to the backend fixes that @RyanHecht mention are being worked on https://github.com/github/gh-classroom/issues/38#issuecomment-1731563468 This adds a very simple retry loop to the base http package with a max retry of 5. 

While this does not fix #38, it does help mitigate what the users see to help smooth out their experience. Hopefully with lowering the default per-page to 15 and this simple loop this error can be less intrusive.

### What approach did you choose and why?

Just a simple retry loop with a max of 5 retry's. 

### What should reviewers focus on?

It would be really nice if the `RESTClient.Get` call returned an error code so we could explicitly check for a 500. As of right now it is embedded in the error string. I guess we could parse  the error code out of a string and if you think that is a better approach let me know :) 

As of right now this simple approach will execute a retry even if the failure was valid as in the case of the user passing in bad data.



I don't know if we want to add in any pauses between retry's to avoid hitting the API too aggressively :) I would assume that github.com could handle the traffic but I don't have any insight to what the backend is doing. 

Thanks for all your efforts :) 