### PR TITLE
Filter directory contents before applying pull to repos

### DIFF
--- a/cmd/gh-classroom/pull/student-repos/student-repos.go
+++ b/cmd/gh-classroom/pull/student-repos/student-repos.go
@@ -71,20 +71,15 @@ func NewCmdStudentReposPull(f *cmdutil.Factory) *cobra.Command {
 				log.Fatal(err)
 			}
 
-			all_entries, err := os.ReadDir(fullPath)
+			entries, err := os.ReadDir(fullPath)
 			if err != nil {
 				log.Fatal(err)
 			}
 
-			//filter entries to only directories
-			var entries []os.DirEntry
-			for _, r := range all_entries {
-				if r.IsDir() {
-					entries = append(entries, r)
-				}
-			}
-
 			for _, r := range entries {
+				if !r.IsDir() {
+					continue
+				}
 				clonePath := filepath.Join(fullPath, r.Name())
 				fmt.Printf("Pulling repo: %v\n", clonePath)
 				err = os.Chdir(clonePath)

--- a/cmd/gh-classroom/pull/student-repos/student-repos.go
+++ b/cmd/gh-classroom/pull/student-repos/student-repos.go
@@ -71,9 +71,17 @@ func NewCmdStudentReposPull(f *cmdutil.Factory) *cobra.Command {
 				log.Fatal(err)
 			}
 
-			entries, err := os.ReadDir(fullPath)
+			all_entries, err := os.ReadDir(fullPath)
 			if err != nil {
 				log.Fatal(err)
+			}
+
+			//filter entries to only directories
+			var entries []os.DirEntry
+			for _, r := range all_entries {
+				if r.IsDir() {
+					entries = append(entries, r)
+				}
 			}
 
 			for _, r := range entries {


### PR DESCRIPTION
### What are you trying to accomplish?

I added a filter for the `pull` command that only looks for local directories in the "x-submissions" folder before running the pulls on each student repo.

This allows companion files to be added to the "x-submissions" folder, such as comment files or tests, that the teacher may use on the student-repos.

fixes #58

### What approach did you choose and why?

I traversed the originally extracted entries and simply applied `isDir()` to add only directories to the list of entries that continue on in the tool's existing code.

I added this change because it offers flexibility to the teacher. It also makes sure that the pull command is only attempting its operations on entries that are directories.

### What should reviewers focus on?

I have run tests on "dirty" parent directories that otherwise fail with the current tool. They work as expected: ignoring files and pulling the repos. It would be important to run further tests on the code validity.

I have limited knowledge and experience with the Go language, so it would be important for someone with experience to make sure that I haven't introduced unintended side effects.
