### PR TITLE
Adds graceful continue

### DIFF
--- a/cmd/gh-classroom/clone/student-repos/student-repos.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos.go
@@ -22,6 +22,7 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 	var page int
 	var perPage int
 	var getAll bool
+	var verbose bool
 
 	cmd := &cobra.Command{
 		Use:   "student-repos",
@@ -90,9 +91,10 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			totalCloned := 0
+			cloneErrors := []string{}
 			for _, acceptAssignment := range acceptedAssignmentList.AcceptedAssignments {
 				clonePath := filepath.Join(fullPath, acceptAssignment.Repository.Name)
-				_, err := CloneRepository(clonePath, acceptAssignment.Repository.FullName, gh)
+				err := utils.CloneRepository(clonePath, acceptAssignment.Repository.FullName, gh.Exec)
 				if err != nil {
 						errMsg := fmt.Sprintf("Error cloning %s: %v", acceptAssignment.Repository.FullName, err)
 						fmt.Println(errMsg)

--- a/cmd/gh-classroom/clone/utils/clone-repository.go
+++ b/cmd/gh-classroom/clone/utils/clone-repository.go
@@ -8,19 +8,16 @@ import (
     "bytes"
 )
 
-// GitHubExec defines an interface for executing GitHub CLI commands.
 // This abstraction allows for easier testing and decoupling from the actual CLI.
 // Exec invokes a gh command in a subprocess and captures the output and error streams.
-type GitHubExec interface {
-    Exec(args ...string) (stdout, stderr bytes.Buffer, err error)
-}
+type GitHubExec func(args ...string) (stdout, stderr bytes.Buffer, err error)
 
 // CloneRepository attempts to clone a repository into the specified path.
 // It returns an error if the cloning process fails.
-func CloneRepository(clonePath string, repoFullName string, gh GitHubExec) error {
+func CloneRepository(clonePath string, repoFullName string, ghExec GitHubExec) error {
     if _, err := os.Stat(clonePath); os.IsNotExist(err) {
         fmt.Printf("Cloning into: %v\n", clonePath)
-        _, _, err := gh.Exec("repo", "clone", repoFullName, "--", clonePath)
+        _, _, err := ghExec("repo", "clone", repoFullName, "--", clonePath)
         if err != nil {
             fmt.Printf("error cloning %s: %v\n", repoFullName, err)
             return fmt.Errorf("error cloning %s: %v", repoFullName, err)

--- a/cmd/gh-classroom/clone/utils/clone-repository.go
+++ b/cmd/gh-classroom/clone/utils/clone-repository.go
@@ -1,0 +1,32 @@
+// cmd/gh-classroom/clone/utils/clone-repository.go
+
+package utils
+
+import (
+    "fmt"
+    "os"
+    "bytes"
+)
+
+// GitHubExec defines an interface for executing GitHub CLI commands.
+// This abstraction allows for easier testing and decoupling from the actual CLI.
+// Exec invokes a gh command in a subprocess and captures the output and error streams.
+type GitHubExec interface {
+    Exec(args ...string) (stdout, stderr bytes.Buffer, err error)
+}
+
+// CloneRepository attempts to clone a repository into the specified path.
+// It returns an error if the cloning process fails.
+func CloneRepository(clonePath string, repoFullName string, gh GitHubExec) error {
+    if _, err := os.Stat(clonePath); os.IsNotExist(err) {
+        fmt.Printf("Cloning into: %v\n", clonePath)
+        _, _, err := gh.Exec("repo", "clone", repoFullName, "--", clonePath)
+        if err != nil {
+            fmt.Printf("error cloning %s: %v\n", repoFullName, err)
+            return fmt.Errorf("error cloning %s: %v", repoFullName, err)
+        }
+        return nil // Success
+    }
+    fmt.Printf("Skip existing repo: %v use gh classroom pull to get new commits\n", clonePath)
+    return fmt.Errorf("repository already exists: %s", clonePath)
+}

--- a/cmd/gh-classroom/clone/utils/clone-repository_test.go
+++ b/cmd/gh-classroom/clone/utils/clone-repository_test.go
@@ -10,16 +10,6 @@ import (
     "path/filepath"
 )
 
-// MockGitHubExec is a mock of the GitHubExec interface for testing.
-type MockGitHubExec struct {
-    ExecFunc func(args ...string) (stdout, stderr bytes.Buffer, err error)
-}
-
-func (m *MockGitHubExec) Exec(args ...string) (stdout, stderr bytes.Buffer, err error) {
-    return m.ExecFunc(args...)
-}
-
-
 func TestCloneRepository(t *testing.T) {
     tmpDir, err := ioutil.TempDir("", "cloneTest")
     if err != nil {
@@ -29,7 +19,7 @@ func TestCloneRepository(t *testing.T) {
     // Test cases
     tests := []struct {
         name       string
-        execMock   *MockGitHubExec
+        execMock   GitHubExec
         clonePath  string
         repoFullName string
         wantErr    bool
@@ -37,12 +27,10 @@ func TestCloneRepository(t *testing.T) {
     }{
         {
             name: "successful clone",
-            execMock: &MockGitHubExec{
-                ExecFunc: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+            execMock: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
                     var stdoutBuf, stderrBuf bytes.Buffer
                     stdoutBuf.Write([]byte("your string here"))
                     return stdoutBuf, stderrBuf, nil
-                },
             },
             clonePath: "", // Will be set to a temp directory in the test
             repoFullName: "example/repo",
@@ -50,11 +38,9 @@ func TestCloneRepository(t *testing.T) {
         },
         {
             name: "clone failure",
-            execMock: &MockGitHubExec{
-                ExecFunc: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+            execMock: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
                     var stdoutBuf, stderrBuf bytes.Buffer
                     return stdoutBuf, stderrBuf, errors.New("clone error")
-                },
             },
             clonePath:  filepath.Join(tmpDir, "repo"),
             repoFullName: "example/repo",
@@ -63,11 +49,9 @@ func TestCloneRepository(t *testing.T) {
         },
         {
             name: "repository already exists",
-            execMock: &MockGitHubExec{
-                ExecFunc: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+            execMock: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
                     var stdoutBuf, stderrBuf bytes.Buffer
                     return stdoutBuf, stderrBuf, nil
-                },
             },
             clonePath:  "./repo", // Current directory always exists
             repoFullName: "example/repo",

--- a/cmd/gh-classroom/clone/utils/clone-repository_test.go
+++ b/cmd/gh-classroom/clone/utils/clone-repository_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-    "io/ioutil"
     "os"
     "testing"
     "bytes"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestCloneRepository(t *testing.T) {
-    tmpDir, err := ioutil.TempDir("", "cloneTest")
+    tmpDir, err := os.MkdirTemp("", "cloneTest")
     if err != nil {
         t.Fatalf("Failed to create temp directory: %v", err)
     }
@@ -65,7 +64,7 @@ func TestCloneRepository(t *testing.T) {
         t.Run(tt.name, func(t *testing.T) {
             if tt.name == "successful clone" {
                 fmt.Println("Running successful clone test")
-                tmpDir, err := ioutil.TempDir("", "cloneTest")
+                tmpDir, err := os.MkdirTemp("", "cloneTest")
                 if err != nil {
                     t.Fatalf("Failed to create temp directory: %v", err)
                 }

--- a/cmd/gh-classroom/clone/utils/clone-repository_test.go
+++ b/cmd/gh-classroom/clone/utils/clone-repository_test.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+    "io/ioutil"
+    "os"
+    "testing"
+    "bytes"
+    "fmt"
+    "errors"
+    "path/filepath"
+)
+
+// MockGitHubExec is a mock of the GitHubExec interface for testing.
+type MockGitHubExec struct {
+    ExecFunc func(args ...string) (stdout, stderr bytes.Buffer, err error)
+}
+
+func (m *MockGitHubExec) Exec(args ...string) (stdout, stderr bytes.Buffer, err error) {
+    return m.ExecFunc(args...)
+}
+
+
+func TestCloneRepository(t *testing.T) {
+    tmpDir, err := ioutil.TempDir("", "cloneTest")
+    if err != nil {
+        t.Fatalf("Failed to create temp directory: %v", err)
+    }
+    defer os.RemoveAll(tmpDir) // clean up
+    // Test cases
+    tests := []struct {
+        name       string
+        execMock   *MockGitHubExec
+        clonePath  string
+        repoFullName string
+        wantErr    bool
+        errMsg     string
+    }{
+        {
+            name: "successful clone",
+            execMock: &MockGitHubExec{
+                ExecFunc: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+                    var stdoutBuf, stderrBuf bytes.Buffer
+                    stdoutBuf.Write([]byte("your string here"))
+                    return stdoutBuf, stderrBuf, nil
+                },
+            },
+            clonePath: "", // Will be set to a temp directory in the test
+            repoFullName: "example/repo",
+            wantErr:    false,
+        },
+        {
+            name: "clone failure",
+            execMock: &MockGitHubExec{
+                ExecFunc: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+                    var stdoutBuf, stderrBuf bytes.Buffer
+                    return stdoutBuf, stderrBuf, errors.New("clone error")
+                },
+            },
+            clonePath:  filepath.Join(tmpDir, "repo"),
+            repoFullName: "example/repo",
+            wantErr:    true,
+            errMsg:     "error cloning example/repo: clone error",
+        },
+        {
+            name: "repository already exists",
+            execMock: &MockGitHubExec{
+                ExecFunc: func(args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+                    var stdoutBuf, stderrBuf bytes.Buffer
+                    return stdoutBuf, stderrBuf, nil
+                },
+            },
+            clonePath:  "./repo", // Current directory always exists
+            repoFullName: "example/repo",
+            wantErr:    true,
+            errMsg:     "repository already exists: .",
+        },
+    }
+
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            if tt.name == "successful clone" {
+                fmt.Println("Running successful clone test")
+                tmpDir, err := ioutil.TempDir("", "cloneTest")
+                if err != nil {
+                    t.Fatalf("Failed to create temp directory: %v", err)
+                }
+                defer os.RemoveAll(tmpDir) // clean up
+                tt.clonePath = filepath.Join(tmpDir, "repo")
+            }
+
+
+            fmt.Println("Running test", tt.name, "with clonePath", tt.clonePath, "and repoFullName", tt.repoFullName)
+            err := CloneRepository(tt.clonePath, tt.repoFullName, tt.execMock)
+            if err != nil && err.Error() != tt.errMsg {
+                t.Errorf("CloneRepository() error = %v, wantErr %v", err, tt.wantErr)
+            }
+        })
+    }
+}

--- a/cmd/gh-classroom/pull/student-repos/student-repos.go
+++ b/cmd/gh-classroom/pull/student-repos/student-repos.go
@@ -80,7 +80,7 @@ func NewCmdStudentReposPull(f *cmdutil.Factory) *cobra.Command {
 				if !r.IsDir() {
 					continue
 				}
-				clonePath := filepath.Join(fullPath, r.Name())
+				clonePath := filepath.Join(fullPath, r.Name)
 				fmt.Printf("Pulling repo: %v\n", clonePath)
 				err = os.Chdir(clonePath)
 				if err != nil {

--- a/cmd/gh-classroom/pull/student-repos/student-repos.go
+++ b/cmd/gh-classroom/pull/student-repos/student-repos.go
@@ -80,7 +80,7 @@ func NewCmdStudentReposPull(f *cmdutil.Factory) *cobra.Command {
 				if !r.IsDir() {
 					continue
 				}
-				clonePath := filepath.Join(fullPath, r.Name)
+				clonePath := filepath.Join(fullPath, r.Name())
 				fmt.Printf("Pulling repo: %v\n", clonePath)
 				err = os.Chdir(clonePath)
 				if err != nil {

--- a/pkg/classroom/classroom.go
+++ b/pkg/classroom/classroom.go
@@ -138,7 +138,3 @@ func (a Assignment) IsGroupAssignment() bool {
 func (a AcceptedAssignment) RepositoryUrl() string {
 	return a.Repository.HtmlUrl
 }
-
-func (gr GithubRepository) Name() string {
-	return strings.Split(gr.FullName, "/")[1]
-}

--- a/pkg/classroom/classroom.go
+++ b/pkg/classroom/classroom.go
@@ -56,7 +56,7 @@ type Classroom struct {
 
 type GithubRepository struct {
 	Id            int    `json:"id"`
-	Name					string `json:name`
+	Name					string `json:"name"`
 	FullName      string `json:"full_name"`
 	HtmlUrl       string `json:"html_url"`
 	NodeId        string `json:"node_id"`

--- a/pkg/classroom/classroom.go
+++ b/pkg/classroom/classroom.go
@@ -2,7 +2,6 @@ package classroom
 
 import (
 	"fmt"
-	"strings"
 )
 
 type AssignmentList struct {
@@ -57,6 +56,7 @@ type Classroom struct {
 
 type GithubRepository struct {
 	Id            int    `json:"id"`
+	Name					string `json:name`
 	FullName      string `json:"full_name"`
 	HtmlUrl       string `json:"html_url"`
 	NodeId        string `json:"node_id"`

--- a/pkg/classroom/classroom.go
+++ b/pkg/classroom/classroom.go
@@ -56,7 +56,7 @@ type Classroom struct {
 
 type GithubRepository struct {
 	Id            int    `json:"id"`
-	Name					string `json:"name"`
+	Name          string `json:"name"`
 	FullName      string `json:"full_name"`
 	HtmlUrl       string `json:"html_url"`
 	NodeId        string `json:"node_id"`

--- a/pkg/classroom/classroom_test.go
+++ b/pkg/classroom/classroom_test.go
@@ -122,10 +122,3 @@ func TestAcceptedAssignments(t *testing.T) {
 		assert.Equal(t, acceptedAssignment.RepositoryUrl(), "https://github.com/owner/repo")
 	})
 }
-
-func TestGithubRepositories(t *testing.T) {
-	t.Run("Returns repo name", func(t *testing.T) {
-		repository := GithubRepository{FullName: "owner/repo"}
-		assert.Equal(t, repository.Name(), "repo")
-	})
-}


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes, including any screenshots or videos if applicable. -->

Fixes a bug where the `gh classroom clone student-repos` command would fail if any repositories could not be cloned and was due to an unhandled error. This PR adds a `--verbose` flag to the command to enable verbose error output and gracefully continue cloning the remaining repositories if any fail.

Closes: #69

### What should reviewers focus on?

<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes. Highlight anything on which you would like a second (or third) opinion. -->

In addition, this PR abstracts the cloning of repositories to a separate function `utils.CloneRepository` to improve testability and maintainability.

This PR also removes the `Name()` function from `acceptAssignment.Repository.Name()` and replaces it with `acceptAssignment.Repository.Name`. On GitHub Classroom, I've opened a PR to update the `Repo` serializer to include the `name` attribute.



