### PR TITLE
Add buffer for observed panic

### DIFF
--- a/pkg/classroom/classroom.go
+++ b/pkg/classroom/classroom.go
@@ -100,6 +100,14 @@ type GitHubOrganization struct {
 }
 
 func NewAssignmentList(assignments []Assignment) AssignmentList {
+	if len(assignments) == 0 {
+    return AssignmentList{
+			Assignments: []Assignment{},
+    	Classroom:   Classroom{},
+    	Count:       0,
+		}
+	}
+
 	classroom := assignments[0].Classroom
 	count := len(assignments)
 
@@ -111,6 +119,15 @@ func NewAssignmentList(assignments []Assignment) AssignmentList {
 }
 
 func NewAcceptedAssignmentList(assignments []AcceptedAssignment) AcceptedAssignmentList {
+	if len(assignments) == 0 {
+		return AcceptedAssignmentList{
+			AcceptedAssignments: []AcceptedAssignment{},
+			Classroom:           Classroom{},
+			Assignment:          Assignment{},
+			Count:               0,
+		}
+	}
+
 	classroom := assignments[0].Assignment.Classroom
 	assignment := assignments[0].Assignment
 	count := len(assignments)

--- a/pkg/classroom/classroom.go
+++ b/pkg/classroom/classroom.go
@@ -101,10 +101,10 @@ type GitHubOrganization struct {
 
 func NewAssignmentList(assignments []Assignment) AssignmentList {
 	if len(assignments) == 0 {
-    return AssignmentList{
+		return AssignmentList{
 			Assignments: []Assignment{},
-    	Classroom:   Classroom{},
-    	Count:       0,
+			Classroom:   Classroom{},
+			Count:       0,
 		}
 	}
 

--- a/pkg/classroom/classroom_test.go
+++ b/pkg/classroom/classroom_test.go
@@ -42,6 +42,11 @@ func TestNewAssignmentList(t *testing.T) {
 
 		assert.Equal(t, assignmentList.Classroom.Name, "The Classroom")
 	})
+
+	t.Run("returns empty list when there are no assignments", func(t *testing.T) {
+		assignmentList := NewAssignmentList([]Assignment{})
+		assert.Equal(t, assignmentList.Count, 0)
+	})
 }
 
 func TestNewAcceptedAssignmentList(t *testing.T) {
@@ -91,6 +96,11 @@ func TestNewAcceptedAssignmentList(t *testing.T) {
 		assignmentList := NewAcceptedAssignmentList(acceptedAssignments)
 
 		assert.Equal(t, assignmentList.Assignment.Title, "The Assignment")
+	})
+
+	t.Run("it returns an empty list when there are no accepted assignments", func(t *testing.T) {
+		assignmentList := NewAcceptedAssignmentList([]AcceptedAssignment{})
+		assert.Equal(t, assignmentList.Count, 0)
 	})
 }
 


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes, including any screenshots or videos if applicable. -->

While trying to debug https://github.com/github/gh-classroom/issues/69 I was running into a panic in the `NewAssignmentList` function. This panic was caused by an empty `assignments` slice being passed to the function. To prevent this panic, I added a check to return an empty `AssignmentList` when the `assignments` slice is empty. I also added a similar check to the `NewAcceptedAssignmentList` function to prevent a panic when an empty `assignments`. 

### What approach did you choose and why?

Since it's expected to be able to return an empty list of AcceptedAssignments or regular Assignments, this is the expected behaviour.
