### PR TITLE
Change default getAll behaviour on clone

### DIFF
--- a/cmd/gh-classroom/clone/student-repos/student-repos.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos.go
@@ -53,6 +53,10 @@ func NewCmdStudentRepo(f *cmdutil.Factory) *cobra.Command {
 					log.Fatal(err)
 				}
 			}
+			
+			// Default getAll to true unless page is set differently from default.
+			getAll = !cmd.Flags().Changed("page")
+
 			var acceptedAssignmentList classroom.AcceptedAssignmentList
 			if getAll {
 				acceptedAssignmentList, err = shared.ListAllAcceptedAssignments(client, assignmentId, perPage)

--- a/cmd/gh-classroom/clone/student-repos/student-repos_test.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos_test.go
@@ -34,6 +34,7 @@ func TestGetAllFlag(t *testing.T) {
         {"Default", []string{}, true},
         {"PerPage Set", []string{"--per-page", "20"}, true},
         {"Page Set", []string{"--page", "2"}, false},
+        {"Page Set to 1", []string{"--page", "1"}, false},
         {"Page and PerPage Set", []string{"--page", "2", "--per-page", "20"}, false},
     }
 

--- a/cmd/gh-classroom/clone/student-repos/student-repos_test.go
+++ b/cmd/gh-classroom/clone/student-repos/student-repos_test.go
@@ -1,0 +1,58 @@
+package student_repos
+
+import (
+    "testing"
+
+    "github.com/spf13/cobra"
+)
+
+// Mock command setup for testing
+func newTestCmd() *cobra.Command {
+    var page, perPage int
+    var getAll bool
+
+    cmd := &cobra.Command{
+        Use: "test-cmd",
+        Run: func(cmd *cobra.Command, args []string) {
+            getAll = !cmd.Flags().Changed("page")
+        },
+    }
+
+    cmd.Flags().IntVar(&page, "page", 1, "Page number")
+    cmd.Flags().IntVar(&perPage, "per-page", 15, "Number of items per page")
+    cmd.Flags().BoolVar(&getAll, "all", true, "Get all items")
+
+    return cmd
+}
+
+func TestGetAllFlag(t *testing.T) {
+    tests := []struct {
+        name     string
+        args     []string
+        expected bool
+    }{
+        {"Default", []string{}, true},
+        {"PerPage Set", []string{"--per-page", "20"}, true},
+        {"Page Set", []string{"--page", "2"}, false},
+        {"Page and PerPage Set", []string{"--page", "2", "--per-page", "20"}, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            cmd := newTestCmd()
+            cmd.SetArgs(tt.args)
+            if err := cmd.Execute(); err != nil {
+                t.Fatalf("cmd.Execute() failed with %v", err)
+            }
+
+            getAllFlag, err := cmd.Flags().GetBool("all")
+            if err != nil {
+                t.Fatalf("Failed to get 'all' flag: %v", err)
+            }
+
+            if getAllFlag != tt.expected {
+                t.Errorf("Expected getAll to be %v, got %v", tt.expected, getAllFlag)
+            }
+        })
+    }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes, including any screenshots or videos if applicable. -->

[User noticed the pagination was cloning all repos](https://github.com/github/gh-classroom/issues/72#issuecomment-2215872611).

This can be avoided by explicitly setting the `--all` flag to `false`, however, the default behaviour should be to clone all repos unless the `--page` flag is set differently from the default.
