### PR TITLE
Fix broken link to golangci-lint install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please note that this project is released with a [Contributor Code of Conduct](.
 These are one time installations required to be able to test your changes locally as part of the pull request (PR) submission process.
 
 1. install Go [through download](https://go.dev/doc/install) | [through Homebrew](https://formulae.brew.sh/formula/go)
-1. [install golangci-lint](https://golangci-lint.run/welcome/install/)
+1. [install golangci-lint](https://golangci-lint.run/docs/welcome/install/)
 
 ## Submitting a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please note that this project is released with a [Contributor Code of Conduct](.
 These are one time installations required to be able to test your changes locally as part of the pull request (PR) submission process.
 
 1. install Go [through download](https://go.dev/doc/install) | [through Homebrew](https://formulae.brew.sh/formula/go)
-1. [install golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
+1. [install golangci-lint](https://golangci-lint.run/welcome/install/)
 
 ## Submitting a pull request
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fix a link that no longer works so someone wanting to contribute will go to the right webpage when trying to install golangci-lint.

fixes Issue #95 

### What approach did you choose and why?

Simply replaced the old URL with the new one; everything else should be the same. I did this because it was the smallest change I could make while still fixing the issue.

### What should reviewers focus on?

It is possible the team actually wants the link to take the user to a different page because the official golangci-lint install page seemed to be a lot. I could see someone getting confused unnecessarily.

An alternate option would be to include instructions for some of the install methods directly in the CONTRIBUTE.md file. If this is desired, feel free to let me know and I will be happy to make that adjustment. Please just tell me if there are any strong preferences on which install methods to include.

Edit: A previous version had the last paragraph saying to include links when I meant to include the instructions themselves.
